### PR TITLE
Prevent an exception if the response is not a valid JSON

### DIFF
--- a/lib/uservoice.js
+++ b/lib/uservoice.js
@@ -148,7 +148,12 @@ UserVoice.prototype.processResponse = function(response_body, options, callback)
 
     // console.log("response_body was " + util.inspect(response_body));
 
-    var res = JSON.parse(response_body);
+    var res;
+    try {
+        res = JSON.parse(response_body);
+    } catch( e ) {
+        res = response_body;
+    }
     if( res ) {
 
         if( result_mapper ) {


### PR DESCRIPTION
This happens for example for GET oauth/request_token
